### PR TITLE
Fix ntapi crate error when compiling on windows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -347,9 +347,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.139"
+version = "0.2.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
+checksum = "302d7ab3130588088d277783b1e2d2e10c9e9e4a16dd9050e6ec93fb3e7048f4"
 
 [[package]]
 name = "link-cplusplus"
@@ -380,9 +380,9 @@ dependencies = [
 
 [[package]]
 name = "ntapi"
-version = "0.3.7"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c28774a7fd2fbb4f0babd8237ce554b73af68021b5f695a3cebd6c59bac0980f"
+checksum = "e8a3895c6391c39d7fe7ebc444a87eb2991b2a0bc718fdabd071eec617fc68e4"
 dependencies = [
  "winapi",
 ]
@@ -575,9 +575,9 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.23.13"
+version = "0.29.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3977ec2e0520829be45c8a2df70db2bf364714d8a748316a10c3c35d4d2b01c9"
+checksum = "cd727fc423c2060f6c92d9534cef765c65a6ed3f428a03d7def74a8c4348e666"
 dependencies = [
  "cfg-if",
  "core-foundation-sys",

--- a/local_crates/crusti_app_helper-v0.1/Cargo.toml
+++ b/local_crates/crusti_app_helper-v0.1/Cargo.toml
@@ -12,4 +12,4 @@ chrono = "0.4.19"
 clap = "2.33.3"
 fern = { version = "0.6.0", features = ["colored"] }
 log = "0.4.11"
-sysinfo = "0.23.9"
+sysinfo = "0.29"

--- a/local_crates/crusti_app_helper-v0.1/src/cli_manager/cli_manager.rs
+++ b/local_crates/crusti_app_helper-v0.1/src/cli_manager/cli_manager.rs
@@ -20,7 +20,7 @@ use anyhow::{anyhow, Result};
 use clap::{App, AppSettings, Arg};
 use log::info;
 use std::{ffi::OsString, str::FromStr};
-use sysinfo::{ProcessorExt, System, SystemExt};
+use sysinfo::{System, SystemExt, CpuExt};
 
 /// A structure used to handle the set of commands and to process the CLI arguments against them.
 pub(crate) struct CliManager<'a> {
@@ -166,7 +166,7 @@ fn sys_info() {
         sys.os_version().unwrap_or_else(unknown),
         sys.kernel_version().unwrap_or_else(unknown)
     );
-    let mut processor_kinds: Vec<&str> = sys.processors().iter().map(|p| p.brand()).collect();
+    let mut processor_kinds: Vec<&str> = sys.cpus().iter().map(|p| p.brand()).collect();
     processor_kinds.sort();
     processor_kinds.dedup();
     info!(


### PR DESCRIPTION
Hello,

I encountered an error when compiling under Windows.

![image](https://github.com/crillab/crusti_g2io/assets/34631206/8487ba50-7f1c-4b55-ba0a-4cc7858b097f)

I explored a bit and it seems that this bug has been fixed in version 0.4 of NTAPI.
So I updated the version number of sysinfo from 0.23 to 0.29 which uses this library in the crusti_app_helper crate.
Sysinfo updates NTAPI to 0.4 in version 0.26.

And this, fix my problem.
What do you think of it ?

